### PR TITLE
OpenAI の APIを使って、ChatGPTにリクエストを投げるクラスを仮実装する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem "ruby-openai"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,9 @@ GEM
     erubi (1.12.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.1.5)
@@ -120,6 +123,7 @@ GEM
     mini_mime (1.1.2)
     minitest (5.18.0)
     msgpack (1.6.1)
+    multi_xml (0.6.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -169,6 +173,8 @@ GEM
     rake (13.0.6)
     regexp_parser (2.7.0)
     rexml (3.2.5)
+    ruby-openai (3.6.0)
+      httparty (>= 0.18.1)
     rubyzip (2.3.2)
     selenium-webdriver (4.8.1)
       rexml (~> 3.2, >= 3.2.5)
@@ -224,6 +230,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.3)
+  ruby-openai
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/models/open_ai_request_service.rb
+++ b/app/models/open_ai_request_service.rb
@@ -1,0 +1,21 @@
+class OpenAiRequestService
+  # TODO: 引数を受け取って、自由にメッセージを送れるようにする
+  def self.call
+    # TODO: initializerに移動する
+    client = OpenAI::Client.new(access_token: ENV.fetch("OPENAI_API_SECRET_KEY"))
+
+    # TODO: specを書いた後に、関数の抽出を行う
+    response = client.chat(
+      parameters: {
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: "おはよう！"}],
+        temperature: 0.7,
+      }
+    )
+    # TODO: レスポンスは仮のもの
+    puts "---------------------"
+    puts response
+    puts "---------------------"
+    puts response.dig("choices", 0, "message", "content")
+  end
+end


### PR DESCRIPTION
## 変更内容
- openai apiにリクエストするための[gem](https://github.com/alexrudall/ruby-openai#chatgpt)を導入する
- 上記gemを使ってリクエストするクラスを仮実装する
  - 仮なので、一旦、全てを同じメソッド内にまとめる
  - spec書いてから、initializerや関数抽出、クラス名・メソッド名、返り値の見直しを行う